### PR TITLE
list<u8> -> wasm-response as return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # wavs-wasi
-wasi-utils and wit files for easy WIT import
+wasi-utils and wit files for easy MIT-license import

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # wavs-wasi
-wasi-utils and wit files for easy MIT import
+wasi-utils and wit files for easy WIT import

--- a/justfile
+++ b/justfile
@@ -2,3 +2,6 @@ lint:
     cargo fmt --all -- --check
     cargo fix --allow-dirty --allow-staged
     cargo clippy --all-targets -- -D warnings
+
+wit-build:
+    wkg wit build

--- a/wit/wavs_worker.wit
+++ b/wit/wavs_worker.wit
@@ -152,7 +152,7 @@ world layer-trigger-world {
     log: func(level: log-level, message: string);
   }
 
-  use layer-types.{trigger-action};
+  use layer-types.{trigger-action, wasm-response};
 
-  export run: func(trigger-action: trigger-action) -> result<option<wasm-response>>, string>;
+  export run: func(trigger-action: trigger-action) -> result<option<wasm-response>, string>;
 }

--- a/wit/wavs_worker.wit
+++ b/wit/wavs_worker.wit
@@ -1,4 +1,4 @@
-package wavs:worker@0.4.0-alpha.1;
+package wavs:worker@0.4.0-alpha.2;
 
 use wasi:io/poll@0.2.0;
 use wasi:clocks/monotonic-clock@0.2.0;
@@ -123,6 +123,11 @@ interface layer-types {
     trigger-time: timestamp
   }
 
+  record wasm-response {
+    payload: list<u8>,
+    ordering: option<u64>
+  }
+
   variant log-level {
     error,
     warn,
@@ -149,5 +154,5 @@ world layer-trigger-world {
 
   use layer-types.{trigger-action};
 
-  export run: func(trigger-action: trigger-action) -> result<option<list<u8>>, string>;
+  export run: func(trigger-action: trigger-action) -> result<option<wasm-response>>, string>;
 }


### PR DESCRIPTION
closes #13 

@Reecepbcups heads up I did not update go bindings or anything there, since the README says 0.3.0, I figured we only update to 0.4.0 when all the dust settles, but if I'm wrong about that and I should rebuild go stuff, lmk and I'll go ahead and do that :)