### PR TITLE
Bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 license = "MIT"
 authors = ["Lay3r Labs Team"]
 repository = "https://github.com/Lay3rLabs/WAVS-WASI"
@@ -17,13 +17,13 @@ anyhow = "1.0.90"
 wstd = "0.5.1"
 wasi = "0.14.0"
 wit-bindgen-rt = { version = "0.39.0", features = ["bitflags", "async"] }
-alloy-primitives = { version = "0.8.20", features = ["serde"] }
-alloy-sol-types = "0.8.20"
-alloy-json-rpc = "0.11.0"
-alloy-provider = "0.11.0"
-alloy-transport-http = "0.11.0"
-alloy-transport = "0.11.0"
-alloy-rpc-client = "0.11.0"
+alloy-primitives = { version = "1.0.0", features = ["serde"] }
+alloy-sol-types = "1.0.0"
+alloy-json-rpc = "0.14.0"
+alloy-provider = "0.14.0"
+alloy-transport-http = "0.14.0"
+alloy-transport = "0.14.0"
+alloy-rpc-client = "0.14.0"
 cfg-if = "1.0.0"
 tower-service = "0.3.3"
 futures-utils-wasm = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.0"
+version = "0.4.0-alpha.3"
 license = "MIT"
 authors = ["Lay3r Labs Team"]
 repository = "https://github.com/Lay3rLabs/WAVS-WASI"

--- a/packages/wavs-wasi-utils/Cargo.toml
+++ b/packages/wavs-wasi-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wavs-wasi-utils"
-version = "0.4.0-alpha.1"
 description = "WAVS WASI utils"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/packages/wavs-wasi-utils/src/ethereum/event.rs
+++ b/packages/wavs-wasi-utils/src/ethereum/event.rs
@@ -35,5 +35,5 @@ pub fn decode_event_log_data_raw<T: alloy_sol_types::SolEvent>(
     let log_data =
         LogData::new(topics, data).ok_or_else(|| anyhow!("failed to create log data"))?;
 
-    T::decode_log_data(&log_data, false).map_err(|e| anyhow!("failed to decode event: {}", e))
+    T::decode_log_data(&log_data).map_err(|e| anyhow!("failed to decode event: {}", e))
 }

--- a/wit/wavs_worker.wit
+++ b/wit/wavs_worker.wit
@@ -1,4 +1,4 @@
-package wavs:worker@0.4.0-alpha.2;
+package wavs:worker@0.4.0-alpha.3;
 
 use wasi:io/poll@0.2.0;
 use wasi:clocks/monotonic-clock@0.2.0;


### PR DESCRIPTION
bumps the deps so we are aligned with `wavs`

already published to `crates.io` and `wa.dev`