### PR TITLE
Publish wasm to wa.dev

### DIFF
--- a/.github/workflows/publish-utils.yml
+++ b/.github/workflows/publish-utils.yml
@@ -2,7 +2,7 @@ name: Publish wavs-wasi-utils to crates.io
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 env:
   CRATE_NAME: wavs-wasi-utils
@@ -31,7 +31,7 @@ jobs:
           VERSION=$(cargo read-manifest --manifest-path ${{ env.CRATE_PATH }}/Cargo.toml | jq -r .version)
           
           # Ensure the tag name matches the version from Cargo.toml
-          if [ "v$VERSION" != "${{ github.ref_name }}" ]; then
+          if [ "$VERSION" != "${{ github.ref_name }}" ]; then
               echo "Error: Tag name '${{ github.ref_name }}' does not match version '$VERSION' from Cargo.toml"
               exit 1
           fi

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -1,0 +1,41 @@
+name: Publish WASM to wa.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish-wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust and Cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Cargo binaries
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}
+
+      - name: Install wkg
+        run: cargo install wkg
+
+      - name: Build wit
+        run: wkg wit build
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "version=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+      - name: Publish wasm to wa.dev
+        run: |
+          version="${{ steps.get_version.outputs.version }}"
+          wkg publish "wavs:worker@$version.wasm"

--- a/wkg.toml
+++ b/wkg.toml
@@ -1,0 +1,6 @@
+[metadata]
+author = "Lay3r Labs Team"
+description = "WAVS WASI interface"
+license = "MIT"
+homepage = "https://www.wavs.xyz/"
+repository = "https://github.com/Lay3rLabs/wavs-wasi"


### PR DESCRIPTION
closes #9 

Adds a wkg.toml for publishing with metadata:

```
[metadata]
author = "Lay3r Labs Team"
description = "WAVS WASI interface"
license = "MIT"
homepage = "https://www.wavs.xyz/"
repository = "https://github.com/Lay3rLabs/wavs-wasi"
```

Going forward, we should run all publish CI with semver tags `'[0-9]+.[0-9]+.[0-9]+*'`. This makes the yml logic easier to read and is more compatible with crates.


This PR implements that on `publish-utils.yml` and `publish-wasm.yml`. The core logic for publish to wa.dev is done, but I'm getting a publish error. Not entirely sure how to configure this atm:

```
wkg publish wavs:worker@0.4.0-test.6.wasm
Error: registry error: keyring error: failed to read signing key for registry <wavs.wa.dev>.
The 'secret-service' keyring backend failed.
You may not have a secret service, such as GNOME Keyring or KWallet, installed or configured.
Consult your OS distribution's documentation for installation instructions.
```

I installed gnome-keyring and then got this error:

```
Error: registry error: keyring error: failed to read signing key for registry <wavs.wa.dev>.

Caused by:
    0: keyring error: failed to read signing key for registry <wavs.wa.dev>.
    1: Couldn't access platform secure storage: SS error: result not returned from SS API
    2: SS error: result not returned from SS API
```