### PR TITLE
add wasi:keyvalue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.5.0-alpha.13"
+version = "0.5.0-alpha.14"
 license = "MIT"
 authors = ["Lay3r Labs Team"]
 repository = "https://github.com/Lay3rLabs/WAVS-WASI"

--- a/wit-definitions/types/wit/lib.wit
+++ b/wit-definitions/types/wit/lib.wit
@@ -1,1 +1,1 @@
-package wavs:types@0.5.0-alpha.13;
+package wavs:types@0.5.0-alpha.14;

--- a/wit-definitions/worker/wit/worker.wit
+++ b/wit-definitions/worker/wit/worker.wit
@@ -1,11 +1,8 @@
-package wavs:worker@0.5.0-alpha.13;
+package wavs:worker@0.5.0-alpha.14;
 
-use wavs:types/core@0.5.0-alpha.13 as core-types;
-use wavs:types/service@0.5.0-alpha.13 as service-types;
-use wavs:types/chain@0.5.0-alpha.13 as chain-types;
-
-use wasi:http/types@0.2.0;
-use wasi:http/outgoing-handler@0.2.0;
+use wavs:types/core@0.5.0-alpha.14 as core-types;
+use wavs:types/service@0.5.0-alpha.14 as service-types;
+use wavs:types/chain@0.5.0-alpha.14 as chain-types;
 
 interface input {
     use core-types.{timestamp};
@@ -87,6 +84,13 @@ interface helpers {
 world wavs-world {
     // include needed for golang support
     include wasi:cli/imports@0.2.0;
+
+    // wasi:http 0.2.6 uses the `imports` style, but for now import each interface separately
+    import wasi:http/types@0.2.0;
+    import wasi:http/outgoing-handler@0.2.0;
+
+    // for key-value store support
+    include wasi:keyvalue/imports@0.2.0-draft2;
 
     import host: interface {
         use chain-types.{evm-chain-config, cosmos-chain-config};

--- a/wit-definitions/worker/wkg.lock
+++ b/wit-definitions/worker/wkg.lock
@@ -19,3 +19,12 @@ registry = "wa.dev"
 requirement = "=0.2.0"
 version = "0.2.0"
 digest = "sha256:5a568e6e2d60c1ce51220e1833cdd5b88db9f615720edc762a9b4a6f36b383bd"
+
+[[packages]]
+name = "wasi:keyvalue"
+registry = "wa.dev"
+
+[[packages.versions]]
+requirement = "=0.2.0-draft2"
+version = "0.2.0-draft2"
+digest = "sha256:18b704b3d1682ab0f63d0a96715352e26977beaf55acd7cc5641a7ca579fb52e"


### PR DESCRIPTION
Adds `wasi:keyvalue` to our world

Also moves the `use` statements for `wasi:http` into `import` statements in the world (I think this is more correct)

Already published on `wa.dev`