### PR TITLE
Bump aggregator versions

### DIFF
--- a/wit-definitions/aggregator/wit/aggregator.wit
+++ b/wit-definitions/aggregator/wit/aggregator.wit
@@ -4,8 +4,8 @@ use wavs:types/core@2.6.0 as core-types;
 use wavs:types/service@2.6.0 as service-types;
 use wavs:types/chain@2.6.0 as chain-types;
 use wavs:types/events@2.6.0 as event-types;
-use wavs:operator/input@2.5.0 as operator-input;
-use wavs:operator/output@2.5.0 as operator-output;
+use wavs:operator/input@2.6.0 as operator-input;
+use wavs:operator/output@2.6.0 as operator-output;
 
 interface input {
     use operator-input.{trigger-action};


### PR DESCRIPTION
for some reason `just set-version 2.6.0` skipped some fields